### PR TITLE
[JUNIT] Fixed bug with relying on class inside description

### DIFF
--- a/allure-junit-adaptor/src/main/java/ru/yandex/qatools/allure/junit/AllureRunListener.java
+++ b/allure-junit-adaptor/src/main/java/ru/yandex/qatools/allure/junit/AllureRunListener.java
@@ -107,7 +107,13 @@ public class AllureRunListener extends RunListener {
     public String getSuiteUid(Description description) {
         String suiteName = description.getClassName();
         if (!getSuites().containsKey(suiteName)) {
-            Description suiteDescription = Description.createSuiteDescription(description.getTestClass());
+            Class testClass = description.getTestClass();
+            Description suiteDescription;
+            if (testClass != null) {
+                suiteDescription = Description.createSuiteDescription(testClass);
+            } else {
+                suiteDescription = Description.createSuiteDescription(description.getClassName());
+            }
             testSuiteStarted(suiteDescription);
         }
         return getSuites().get(suiteName);

--- a/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/junit/AllureRunListenerTest.java
+++ b/allure-junit-adaptor/src/test/java/ru/yandex/qatools/allure/junit/AllureRunListenerTest.java
@@ -1,7 +1,6 @@
 package ru.yandex.qatools.allure.junit;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.AssumptionViolatedException;
@@ -20,9 +19,10 @@ import ru.yandex.qatools.allure.events.TestSuiteFinishedEvent;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -185,7 +185,7 @@ public class AllureRunListenerTest {
         runListener.getSuiteUid(description);
 
         verify(runListener).testSuiteStarted(generatedDescription.capture());
-        Assert.assertEquals(className, generatedDescription.getValue().getClassName());
+        assertThat(generatedDescription.getValue().getClassName(), equalTo(className));
 
     }
 


### PR DESCRIPTION
Some frameworks based on top of JUnit don't provide real class names in `Description` (which is totally legal, see motivation below), so trying to do something like this:

```java
Description.createSuiteDescription(description.getTestClass());
```

lead us to `NullPointerException`, cause inside `Desrctiption#createSuiteDescription(Class<?>)` we have:

```java
return new Description(testClass, testClass.getName(), testClass.getAnnotations());
```

## Motivation

Copy-paste from JUnit
```java
/**
 * Create a <code>Description</code> of a single test named <code>name</code> in the 'class' named
 * <code>className</code>. Generally, this will be a leaf <code>Description</code>. This method is a better choice
 * than {@link #createTestDescription(Class, String, Annotation...)} for test runners whose test cases are not
 * defined in an actual Java <code>Class</code>.
 *
 * @param className the class name of the test
 * @param name the name of the test (a method name for test annotated with {@link org.junit.Test})
 * @param annotations meta-data about the test, for downstream interpreters
 * @return a <code>Description</code> named <code>name</code>
 */
public static Description createTestDescription(String className, String name, Annotation... annotations) {
    return new Description(null, formatDisplayName(name, className), annotations);
}
```

And example of framework based on JUnit, which uses this method: [kotlintest](https://github.com/kotlintest/kotlintest)