### PR TITLE
Added support to parameterized @Title annotation (fixes #945)

### DIFF
--- a/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureTitlesAspects.java
+++ b/allure-java-aspects/src/main/java/ru/yandex/qatools/allure/aspects/AllureTitlesAspects.java
@@ -1,0 +1,55 @@
+package ru.yandex.qatools.allure.aspects;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.annotations.Title;
+import ru.yandex.qatools.allure.events.TestCaseEvent;
+import ru.yandex.qatools.allure.model.TestCaseResult;
+
+import static ru.yandex.qatools.allure.aspects.AllureAspectUtils.getTitle;
+
+/**
+ * @author Elena Kudryashova
+ */
+@Aspect
+public class AllureTitlesAspects {
+    private static Allure ALLURE = Allure.LIFECYCLE;
+
+    @Pointcut("@annotation(ru.yandex.qatools.allure.annotations.Title)")
+    public void withTitleAnnotation() {
+        // Pointcut body, should be empty.
+    }
+
+    @Pointcut("execution(* *(..))")
+    public void anyMethod() {
+        // Pointcut body, should be empty.
+    }
+
+    @Before("anyMethod() && withTitleAnnotation()")
+    public void testCaseStart(JoinPoint joinPoint) {
+        final String testCaseTitle = createTitle(joinPoint);
+        ALLURE.fire(new TestCaseEvent() {
+            @Override
+            public void process(TestCaseResult testCaseResult) {
+                testCaseResult.setTitle(testCaseTitle);
+            }
+        });
+    }
+
+    public String createTitle(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        Title title = methodSignature.getMethod().getAnnotation(Title.class);
+        return title == null ? "" : getTitle(title.value(), methodSignature.getName(), joinPoint.getThis(), joinPoint.getArgs());
+    }
+
+    /**
+     * For tests only
+     */
+    static void setAllure(Allure allure) {
+        AllureTitlesAspects.ALLURE = allure;
+    }
+}

--- a/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AspectTest.java
+++ b/allure-java-aspects/src/test/java/ru/yandex/qatools/allure/aspects/AspectTest.java
@@ -1,7 +1,6 @@
 package ru.yandex.qatools.allure.aspects;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import ru.yandex.qatools.allure.Allure;
@@ -32,6 +31,7 @@ public class AspectTest {
     public void setUp() throws Exception {
         AllureStepsAspects.setAllure(allure);
         AllureAttachAspects.setAllure(allure);
+        AllureTitlesAspects.setAllure(allure);
     }
 
     @Test


### PR DESCRIPTION
You can add placeholders like `{0}` into `@Title` annotations for getting the parameterized title in the report (like with `@Step` annotations).